### PR TITLE
fix(cli): ignore error on no ip address verification

### DIFF
--- a/.github/actions/container-build-buildah/action.yaml
+++ b/.github/actions/container-build-buildah/action.yaml
@@ -61,7 +61,7 @@ runs:
       run: |
         PR_NUMBER=pr-$(echo $GITHUB_REF | cut -d '/' -f3)
         buildah tag ${{ inputs.image }}:${GITHUB_SHA} ${{ inputs.image }}:${PR_NUMBER}
-        buildah push ${{ inputs.image }}:${PR_NUMBER}}
+        buildah push ${{ inputs.image }}:${PR_NUMBER}
 
     - name: Tag Image with Version
       shell: bash

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -16,6 +16,6 @@ jobs:
 
   test:
     uses: ./.github/workflows/reusable-test.yaml
-  
+
   lint:
     uses: ./.github/workflows/reusable-lint.yaml

--- a/src/censys/cloud_connectors/azure_connector/provider_setup.py
+++ b/src/censys/cloud_connectors/azure_connector/provider_setup.py
@@ -1,4 +1,5 @@
 """Azure specific setup CLI."""
+import contextlib
 from typing import Optional
 
 from azure.core.exceptions import ClientAuthenticationError, HttpResponseError
@@ -193,7 +194,8 @@ class AzureSetupCli(ProviderSetupCli):
         for subscription_id in provider_setting.subscription_id:
             network_client = NetworkManagementClient(credential, subscription_id)
             res = network_client.public_ip_addresses.list_all()
-            next(res)
+            with contextlib.suppress(StopIteration):
+                next(res)
         return True
 
     def setup_with_cli(self) -> None:


### PR DESCRIPTION
Fixed an issue with verifying that the Azure Service Principle was created correctly. Previously failing when there are no IP addresses to list.