### PR TITLE
[AP-1381] fix: don't repeat api calls for s3 buckets

### DIFF
--- a/src/censys/cloud_connectors/aws_connector/connector.py
+++ b/src/censys/cloud_connectors/aws_connector/connector.py
@@ -118,6 +118,7 @@ class AwsCloudConnector(CloudConnector):
                 self.account_number = credential["account_number"]
                 self.ignored_tags = self.get_ignored_tags(credential["ignore_tags"])
 
+                # for each account + region combination, run each seed scanner
                 for region in self.provider_settings.regions:
                     self.temp_sts_cred = None
                     self.region = region
@@ -137,6 +138,8 @@ class AwsCloudConnector(CloudConnector):
                         )
                         self.dispatch_event(EventTypeEnum.SCAN_FAILED, exception=e)
                     self.region = None
+
+                # for each account, run each cloud asset scanner
                 try:
                     with Healthcheck(
                         self.settings,

--- a/src/censys/cloud_connectors/common/connector.py
+++ b/src/censys/cloud_connectors/common/connector.py
@@ -175,7 +175,7 @@ class CloudConnector(ABC):
         )
 
     def submit_seeds(self):
-        """Submit the seeds to the Censys ASM."""
+        """Submit the seeds to Censys ASM."""
         submitted_seeds = 0
         for label, seeds in self.seeds.items():
             try:
@@ -189,7 +189,7 @@ class CloudConnector(ABC):
         self.dispatch_event(EventTypeEnum.SEEDS_SUBMITTED, count=submitted_seeds)
 
     def submit_cloud_assets(self):
-        """Submit the cloud assets to the Censys ASM."""
+        """Submit the cloud assets to Censys ASM."""
         submitted_assets = 0
         for uid, cloud_assets in self.cloud_assets.items():
             try:
@@ -210,18 +210,52 @@ class CloudConnector(ABC):
         self.cloud_assets.clear()
 
     def submit(self):  # pragma: no cover
-        """Submit the seeds and cloud assets to the Censys ASM."""
+        """Submit the seeds and cloud assets to Censys ASM."""
         if self.settings.dry_run:
             self.logger.info("Dry run enabled. Skipping submission.")
         else:
-            self.logger.info("Submitting seeds and assets...")
+            self.logger.info("Submitting seeds and cloud assets...")
             self.submit_seeds()
             self.submit_cloud_assets()
         self.clear()
 
+    def submit_seeds_wrapper(self):  # pragma: no cover
+        """Submit the seeds to Censys ASM."""
+        if self.settings.dry_run:
+            self.logger.info("Dry run enabled. Skipping submission.")
+        else:
+            self.logger.info("Submitting seeds...")
+            self.submit_seeds()
+        self.clear()
+
+    def submit_cloud_assets_wrapper(self):  # pragma: no cover
+        """Submit the cloud assets to Censys ASM."""
+        if self.settings.dry_run:
+            self.logger.info("Dry run enabled. Skipping submission.")
+        else:
+            self.logger.info("Submitting cloud assets...")
+            self.submit_cloud_assets()
+        self.clear()
+
+    def scan_seeds(self):
+        """Scan the seeds."""
+        self.logger.info("Gathering seeds...")
+        self.dispatch_event(EventTypeEnum.SCAN_STARTED)
+        self.get_seeds()
+        self.submit_seeds_wrapper()
+        self.dispatch_event(EventTypeEnum.SCAN_FINISHED)
+
+    def scan_cloud_assets(self):
+        """Scan the cloud assets."""
+        self.logger.info("Gathering cloud assets...")
+        self.dispatch_event(EventTypeEnum.SCAN_STARTED)
+        self.get_cloud_assets()
+        self.submit_cloud_assets_wrapper()
+        self.dispatch_event(EventTypeEnum.SCAN_FINISHED)
+
     def scan(self):
         """Scan the seeds and cloud assets."""
-        self.logger.info("Gathering seeds and assets...")
+        self.logger.info("Gathering seeds and cloud assets...")
         self.dispatch_event(EventTypeEnum.SCAN_STARTED)
         self.get_seeds()
         self.get_cloud_assets()

--- a/tests/test_aws_connector.py
+++ b/tests/test_aws_connector.py
@@ -179,7 +179,10 @@ class TestAwsConnector(BaseConnectorCase, TestCase):
         self.connector.settings.providers[self.connector.provider] = provider_settings
 
         # Mock scan
-        mock_scan = self.mocker.patch.object(self.connector, "scan")
+        mock_scan_seeds = self.mocker.patch.object(self.connector, "scan_seeds")
+        mock_scan_cloud_assets = self.mocker.patch.object(
+            self.connector, "scan_cloud_assets"
+        )
         mock_healthcheck = self.mock_healthcheck()
 
         # Actual call
@@ -187,8 +190,10 @@ class TestAwsConnector(BaseConnectorCase, TestCase):
 
         # Assertions
         expected_calls = 3
-        assert mock_scan.call_count == expected_calls
-        self.assert_healthcheck_called(mock_healthcheck, expected_calls)
+        expected_healthcheck_calls = 6
+        assert mock_scan_seeds.call_count == expected_calls
+        assert mock_scan_cloud_assets.call_count == expected_calls
+        self.assert_healthcheck_called(mock_healthcheck, expected_healthcheck_calls)
 
     # TODO test multiple account_numbers with multiple regions
     # TODO test single account_number with multiple regions


### PR DESCRIPTION
The way we scan both seeds and cloud assets for AWS is by iterating through account and region within that account
```
for account in accounts:
  for region in regions:
    for resource_type in resource_types:
      * run seed scanners and cloud asset scanner
      # for the seed scanners (API gateway, Load balancer, ENI, RDS, Route53, ECS), the label is created with the [account, region, resource_type] defined at the top of each iteration of the for loop
      # for the cloud asset scanner (S3), the uid (label) is created with the [account, resource_type] defined at the top of each iteration of the for loop, but uses the region found within the S3 bucket.
```
So we are running the API request to get s3 buckets in each iteration of region, but getting the results for all the buckets every time. We only need to scan for s3 buckets once per account, not once per account+region.
Changing the structure **for AWS** to be
```
for account in accounts:
  * run cloud asset scanner
  for region in regions:
    for resource_type in resource_types:
      * run seed scanners
```
we’ll cut out a lot of excess API calls and make removing stale cloud assets easier.


[[AP-1381]](https://censysio.atlassian.net/browse/AP-1381)