### PR TITLE
[AP-2749] Azure stale seeds removal workaround

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,6 +4,7 @@ PROVIDERS_CONFIG_FILE=./providers.yml
 LOGGING_LEVEL=INFO
 DRY_RUN=false
 HEALTHCHECK_ENABLED=true
+AZURE_REFRESH_ALL_REGIONS=false
 
 # Censys API Settings
 # CENSYS_ASM_API_BASE_URL=https://app.censys.io/api

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -105,6 +105,16 @@ If set to `false`, the connector will not report its health to the ASM platform.
 Default: `true`
 ```
 
+```{envvar} AZURE_REFRESH_ALL_REGIONS
+
+Azure-specific environmental variable. If set to `true`, the connector will
+clear stale seeds from regions no longer containing assets. This may take
+longer to run, but will ensure that the connector is not submitting stale seeds.
+If set to `false`, the connector will submit seeds that are found as normal.
+
+Default: `false`
+```
+
 ### Sample `.env` File
 
 `.env.sample` is a sample file that contains the above environment variables.

--- a/src/censys/cloud_connectors/common/settings.py
+++ b/src/censys/cloud_connectors/common/settings.py
@@ -184,6 +184,11 @@ class Settings(BaseSettings):
         env="HEALTHCHECK_ENABLED",
         description="Enable healthcheck",
     )
+    azure_refresh_all_regions: bool = Field(
+        default=False,
+        env="AZURE_REFRESH_ALL_REGIONS",
+        description="Scan all available Azure regions",
+    )
 
     # Verification timeout
     validation_timeout: int = Field(

--- a/tests/test_azure_connector.py
+++ b/tests/test_azure_connector.py
@@ -97,9 +97,23 @@ class TestAzureCloudConnector(BaseConnectorCase, TestCase):
             p.get_provider_key(): p for p in test_azure_settings
         }
         self.connector.settings.providers[self.connector.provider] = provider_settings
+        test_possible_labels = [
+            "Azure: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/global",
+            "Azure: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/eastus",
+            "Azure: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/southcentralus",
+            "Azure: yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy/global",
+            "Azure: yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy/eastus",
+            "Azure: yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy/southcentralus",
+        ]
 
         # Mock scan
         mock_scan = self.mocker.patch.object(self.connector, "scan")
+
+        # Mock get all labels
+        self.mocker.patch.object(self.connector, "get_all_labels")
+        self.mocker.patch.object(
+            self.connector, "possible_labels", test_possible_labels
+        )
 
         # Actual call
         self.connector.scan_all()


### PR DESCRIPTION
If environmental variable `AZURE_REFRESH_ALL_REGIONS` is set to true:
Instead of only submitting seeds with labels that were just found, also submit an empty seed list for all other possible labels (subscription+region combination).

The structure of the Azure scan will be:
```
for subscription in subscriptions:
  # populate list of all possible labels for this subscription
  # scan
    - submit seeds found
    - remove labels found from list described above
  # submit empty list for remaining labels in list
```