### PR TITLE
ci: force build before release

### DIFF
--- a/.github/workflows/release-ci.yaml
+++ b/.github/workflows/release-ci.yaml
@@ -17,3 +17,4 @@ jobs:
   release:
     uses: ./.github/workflows/reusable-release-pypi.yaml
     secrets: inherit
+    needs: build


### PR DESCRIPTION
Force `build` to complete before `release` in Release CI action