### PR TITLE
fix: don't push github tag from action

### DIFF
--- a/.github/workflows/release-ci.yaml
+++ b/.github/workflows/release-ci.yaml
@@ -12,7 +12,8 @@ jobs:
     secrets: inherit
     with:
       tag: "latest"
-      version: true
+      # version: true
+      # Note: commenting above line out until create-version-tag action works
 
   release:
     uses: ./.github/workflows/reusable-release-pypi.yaml


### PR DESCRIPTION
The `Create Version Tag` github action is not working, so I am removing the call to it until we can figure out a solution. For now, Github tags will be pushed manually with releases.