### PR TITLE
fix: reset aws temp creds between account scans

### DIFF
--- a/src/censys/cloud_connectors/aws_connector/connector.py
+++ b/src/censys/cloud_connectors/aws_connector/connector.py
@@ -141,6 +141,8 @@ class AwsCloudConnector(CloudConnector):
 
                 # for each account, run each cloud asset scanner
                 try:
+                    self.temp_sts_cred = None
+                    self.region = None
                     with Healthcheck(
                         self.settings,
                         provider_setting,


### PR DESCRIPTION
Account for case where a cloud connector instance only scans for cloud assets, not seeds. Reset temp STS creds before scanning for cloud assets.