### PR TITLE
fix: exclude cloud assets from gcp seed count

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -109,8 +109,9 @@ Default: `true`
 
 Azure-specific environmental variable. If set to `true`, the connector will
 clear stale seeds from regions no longer containing assets. This may take
-longer to run, but will ensure that the connector is not submitting stale seeds.
-If set to `false`, the connector will submit seeds that are found as normal.
+longer to run, but will ensure that stale seeds do not persist in the
+workspace. If set to `false`, the connector will submit seeds that are found
+as normal.
 
 Default: `false`
 ```

--- a/src/censys/cloud_connectors/gcp_connector/connector.py
+++ b/src/censys/cloud_connectors/gcp_connector/connector.py
@@ -498,7 +498,6 @@ class GcpCloudConnector(CloudConnector):
                             scan_data=scan_data,
                         )
                         self.add_cloud_asset(bucket_asset)
-                        self.found_projects.add(project_number)
             except (
                 json.decoder.JSONDecodeError,
                 ValueError,


### PR DESCRIPTION
For projects with only cloud assets and no seeds, an empty list is not being submitted to that label like it should.