### PR TITLE
fix: scan and documentation issues

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -49,7 +49,7 @@ flag to ensure the container is removed after it has finished.
         -v $(pwd)/providers.yml:/app/providers.yml \
         -v $(pwd)/secrets:/app/secrets \
         gcr.io/censys-io/censys-cloud-connector:latest \
-        scan --daemon 4
+        /app/.venv/bin/censys-cc scan --daemon 4
     ```
 
     ```{admonition} Note

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "censys-cloud-connectors"
-version = "3.2.0"
+version = "3.2.1"
 description = "The Censys Unified Cloud Connector is a standalone connector that gathers assets from various cloud providers and stores them in Censys ASM."
 authors = ["Censys, Inc. <support@censys.io>"]
 license = "Apache-2.0"

--- a/src/censys/cloud_connectors/azure_connector/connector.py
+++ b/src/censys/cloud_connectors/azure_connector/connector.py
@@ -209,7 +209,6 @@ class AzureCloudConnector(CloudConnector):
         try:
             zones = dns_client.zones.list()
         except HttpResponseError as error:
-            # TODO: Better error handling here - consolidate common error handling
             self.logger.error(f"Failed to get Azure DNS records: {error.message}")
             return
 

--- a/src/censys/cloud_connectors/azure_connector/connector.py
+++ b/src/censys/cloud_connectors/azure_connector/connector.py
@@ -104,7 +104,9 @@ class AzureCloudConnector(CloudConnector):
                 try:
                     if self.scan_all_regions:
                         self.get_all_labels()
+
                     self.scan()
+
                     if self.scan_all_regions:
                         for label_not_found in self.possible_labels:
                             self.delete_seeds_by_label(label_not_found)

--- a/terraform/aws-ecs-task/README.md
+++ b/terraform/aws-ecs-task/README.md
@@ -13,8 +13,7 @@ This module allows Terraform to manage
 ## Login Instructions
 
 Use the [AWS CLI][aws-cli] tool to configure a [named profile][aws-cli-named-profile].
-You can set the profile to use with the variable `aws_profile`. This can be
-defined using a Terraform [variable definition file][tf-var-def-file].
+The AWS Terraform provider uses standard [configuration and credential precedence][aws-config-creds].
 
 ## Setup
 
@@ -145,5 +144,5 @@ terraform destroy -var-file terraform.tfvars
 <!-- References -->
 [aws-cli]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html
 [aws-cli-named-profile]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
-[tf-var-def-file]: https://www.terraform.io/language/values/variables#variable-definitions-tfvars-files
+[aws-config-creds]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html
 [tf-aws-auth]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration


### PR DESCRIPTION
- Fix docker documentation error (scan daemon)
- Fix Azure DNS stack trace being shown
- Fix uncaught subscription error within Azure
- Remove reference to `aws_profile` in AWS ECS terraform deployment