### PR TITLE
Catch Azure exceptions gracefully

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -10,7 +10,7 @@ exclude =
     build,
     # This contains builds of flake8 that we don't want to check
     dist
-ignore = E203,E501,W503
+ignore = E203,E501,W503,N818
 per-file-ignores =
     tests/*.py:D100,D101,D102,D103,D104,D107,DAR101
 # flake8-docstrings

--- a/docs/azure/provider_setup.md
+++ b/docs/azure/provider_setup.md
@@ -16,6 +16,12 @@ Use our {doc}`../cli` to step through the configuration process:
 censys-cc config --provider azure
 ```
 
+```{admonition} Note
+:class: censys
+Running the provider setup will overwrite any existing Service Principals with
+the name `Censys Cloud Connector`.
+```
+
 ### Roles and Permissions
 
 Azure uses [role-based access control][azure-rbac]. Ensure that your account's

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -51,6 +51,51 @@ The client 'user@example.com' with object id 'uuid' does not have authorization 
 ```
 <!-- markdownlint-enable MD013 -->
 
+### Why does the Cloud Connector say that my Azure subscription does not exist?
+
+There are two cases where the Cloud Connector might report that your Azure
+subscription does not exist.
+
+#### Case 1: Your providers.yaml file includes a non-existent subscription ID
+
+If you encounter this error:
+
+<!-- markdownlint-disable MD013 -->
+```{code-block}
+Failed to get Azure <RESOURCE_TYPE>: (SubscriptionNotFound) The subscription <SUBSCRIPTION_ID> could not be found.
+```
+<!-- markdownlint-enable MD013 -->
+
+Check to see if this subscription ID exists within the Azure tenant you've
+defined in your providers.yaml file.
+
+#### Case 2: Your Azure Subscription is empty or has unregistered resource providers
+
+If you encounter an error like this:
+
+<!-- markdownlint-disable MD013 -->
+```{code-block}
+Error scanning Microsoft.Network/dnszones: (BadRequest) The specified subscription <SUBSCRIPTION_ID> does not exist
+```
+<!-- markdownlint-enable MD013 -->
+
+Check in your Azure portal if this subscription is empty. Azure reports this
+error if the "Resource Provider" we are trying to access is not registered
+for this subscription and there are no resources of this type in this
+subscription. You can check this by going to the subscription in question in
+your Azure portal, and clicking on "Resource Providers" in the left-hand menu.
+If the resource provider you are trying to access is not listed, you will need
+to register it.
+
+For example, the error shown above is for the `Microsoft.Network/dnszones`
+resource provider. To register this resource provider, you would click on
+"Microsoft.Network" in the list of resource providers, and then click the
+"Register" button at the top of the page.
+
+This is a non-fatal error, so it will not prevent the Cloud Connector from
+scanning the rest of the resource types in this subscription, or the rest of
+the subscriptions in your providers.yaml file.
+
 ## GCP
 
 ### GCP Service Account Keys

--- a/kubernetes/censys-cloud-connectors/README.md
+++ b/kubernetes/censys-cloud-connectors/README.md
@@ -118,6 +118,7 @@ Censys Cloud Connector Chart.
 | --------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `envSecretName`             | The name of the secret containing the .env file.                                                                            |
 | `providersSecretName`       | The name of the secret containing the providers.yml file.                                                                   |
+| `credentialsSecretName`     | (Optional) The name of the secret containing all the credentials stored in the secrets directory.                            |
 | `nameOverride`              | (Optional) The override for the name of the chart.                                                                          |
 | `fullnameOverride`          | (Optional) The override for the fullname (including release name) of the chart.                                             |
 | `imagePullSecrets`          | (Optional) The authorization token to use when accessing the docker registry.                                               |

--- a/kubernetes/censys-cloud-connectors/README.md
+++ b/kubernetes/censys-cloud-connectors/README.md
@@ -97,17 +97,19 @@ available configuration options.
 helm upgrade --install censys-cloud-connectors ./kubernetes/censys-cloud-connectors
 ```
 
-8. Run the Censys Cloud Connector Manually
+8. Optionally test:
 
-```{prompt} bash
-kubectl create job --from=cronjob/censys-cloud-connectors censys-cloud-connectors-manual --dry-run=client -o yaml | kubectl apply -f -
-```
+- Run the Censys Cloud Connector Manually
 
-9. Check the logs of the Censys Cloud Connector Job
+  ```{prompt} bash
+  kubectl create job --from=cronjob/censys-cloud-connectors censys-cloud-connectors-manual --dry-run=client -o yaml | kubectl apply -f -
+  ```
 
-```{prompt} bash
-kubectl logs job.batch/censys-cloud-connectors-manual --follow
-```
+- Check the logs of the Censys Cloud Connector Job
+
+  ```{prompt} bash
+  kubectl logs job.batch/censys-cloud-connectors-manual --follow
+  ```
 <!-- markdownlint-enable MD029 -->
 ## Configuration
 

--- a/src/censys/cloud_connectors/azure_connector/connector.py
+++ b/src/censys/cloud_connectors/azure_connector/connector.py
@@ -267,6 +267,9 @@ class AzureCloudConnector(CloudConnector):
                             self.add_seed(ip_seed)
                             self.possible_labels.discard(label)
 
+        # Note: The generic AzureError is used to ensure the connector does not
+        # fail entirely if the exception is not fatal.
+        # See ticket AP-3180 for future improvements to error handling.
         except AzureError as error:
             raise CensysAzureException(
                 message=f"Failed to get Azure DNS records: {error.message}"

--- a/src/censys/cloud_connectors/azure_connector/connector.py
+++ b/src/censys/cloud_connectors/azure_connector/connector.py
@@ -3,8 +3,8 @@ from collections.abc import Generator
 from typing import Optional
 
 from azure.core.exceptions import (
+    AzureError,
     ClientAuthenticationError,
-    HttpResponseError,
     ServiceRequestError,
 )
 from azure.identity import ClientSecretCredential
@@ -22,6 +22,7 @@ from censys.cloud_connectors.common.cloud_asset import AzureContainerAsset
 from censys.cloud_connectors.common.connector import CloudConnector
 from censys.cloud_connectors.common.context import SuppressValidationError
 from censys.cloud_connectors.common.enums import EventTypeEnum, ProviderEnum
+from censys.cloud_connectors.common.exceptions import CensysAzureException
 from censys.cloud_connectors.common.healthcheck import Healthcheck
 from censys.cloud_connectors.common.seed import DomainSeed, IpSeed
 from censys.cloud_connectors.common.settings import Settings
@@ -135,113 +136,141 @@ class AzureCloudConnector(CloudConnector):
         return f"{self.label_prefix}{self.subscription_id}/{asset_location}"
 
     def get_ip_addresses(self):
-        """Get Azure IP addresses."""
+        """Get Azure IP addresses.
+
+        Raises:
+            CensysAzureException: If Azure reports an error.
+        """
         network_client = NetworkManagementClient(self.credentials, self.subscription_id)
+
         try:
             assets = network_client.public_ip_addresses.list_all()
-        except HttpResponseError as error:
-            self.logger.error(f"Failed to get Azure IP addresses: {error.message}")
-            return
 
-        for asset in assets:
-            asset_dict = asset.as_dict()
-            if ip_address := asset_dict.get("ip_address"):
-                with SuppressValidationError():
-                    label = self.format_label(asset)
-                    ip_seed = IpSeed(value=ip_address, label=label)
-                    self.add_seed(ip_seed)
-                    self.possible_labels.discard(label)
+            for asset in assets:
+                asset_dict = asset.as_dict()
+                if ip_address := asset_dict.get("ip_address"):
+                    with SuppressValidationError():
+                        label = self.format_label(asset)
+                        ip_seed = IpSeed(value=ip_address, label=label)
+                        self.add_seed(ip_seed)
+                        self.possible_labels.discard(label)
+
+        except AzureError as error:
+            raise CensysAzureException(
+                message=f"Failed to get Azure IP Addresses: {error.message}"
+            )
 
     def get_clusters(self):
-        """Get Azure clusters."""
+        """Get Azure clusters.
+
+        Raises:
+            CensysAzureException: If Azure reports an error.
+        """
         container_client = ContainerInstanceManagementClient(
             self.credentials, self.subscription_id
         )
+
         try:
             assets = container_client.container_groups.list()
-        except HttpResponseError as error:
-            self.logger.error(
-                f"Failed to get Azure Container Instances: {error.message}"
-            )
-            return
 
-        for asset in assets:
-            asset_dict = asset.as_dict()
-            if (
-                (ip_address_dict := asset_dict.get("ip_address"))
-                and (ip_address_dict.get("type") == "Public")
-                and (ip_address := ip_address_dict.get("ip"))
-            ):
-                label = self.format_label(asset)
-                with SuppressValidationError():
-                    ip_seed = IpSeed(value=ip_address, label=label)
-                    self.add_seed(ip_seed)
-                    self.possible_labels.discard(label)
-                if domain := ip_address_dict.get("fqdn"):
-                    with SuppressValidationError():
-                        domain_seed = DomainSeed(value=domain, label=label)
-                        self.add_seed(domain_seed)
-                        self.possible_labels.discard(label)
-
-    def get_sql_servers(self):
-        """Get Azure SQL servers."""
-        sql_client = SqlManagementClient(self.credentials, self.subscription_id)
-        try:
-            assets = sql_client.servers.list()
-        except HttpResponseError as error:
-            self.logger.error(f"Failed to get Azure SQL servers: {error.message}")
-            return
-
-        for asset in assets:
-            asset_dict = asset.as_dict()
-            if (
-                domain := asset_dict.get("fully_qualified_domain_name")
-            ) and asset_dict.get("public_network_access") == "Enabled":
-                with SuppressValidationError():
-                    label = self.format_label(asset)
-                    domain_seed = DomainSeed(value=domain, label=label)
-                    self.add_seed(domain_seed)
-                    self.possible_labels.discard(label)
-
-    def get_dns_records(self):
-        """Get Azure DNS records."""
-        dns_client = DnsManagementClient(self.credentials, self.subscription_id)
-        try:
-            zones = dns_client.zones.list()
-        except HttpResponseError as error:
-            self.logger.error(f"Failed to get Azure DNS records: {error.message}")
-            return
-
-        for zone in zones:
-            zone_dict = zone.as_dict()
-            label = self.format_label(zone)
-            # TODO: Do we need to check if zone is public? (ie. do we care?)
-            if zone_dict.get("zone_type") != "Public":  # pragma: no cover
-                continue
-            zone_resource_group = zone_dict.get("id").split("/")[4]
-            for asset in dns_client.record_sets.list_all_by_dns_zone(
-                zone_resource_group, zone_dict.get("name")
-            ):
+            for asset in assets:
                 asset_dict = asset.as_dict()
-                if domain_name := asset_dict.get("fqdn"):
-                    with SuppressValidationError():
-                        domain_seed = DomainSeed(value=domain_name, label=label)
-                        self.add_seed(domain_seed)
-                        self.possible_labels.discard(label)
-                if cname := asset_dict.get("cname_record", {}).get("cname"):
-                    with SuppressValidationError():
-                        domain_seed = DomainSeed(value=cname, label=label)
-                        self.add_seed(domain_seed)
-                        self.possible_labels.discard(label)
-                for a_record in asset_dict.get("a_records", []):
-                    ip_address = a_record.get("ipv4_address")
-                    if not ip_address:
-                        continue
-
+                if (
+                    (ip_address_dict := asset_dict.get("ip_address"))
+                    and (ip_address_dict.get("type") == "Public")
+                    and (ip_address := ip_address_dict.get("ip"))
+                ):
+                    label = self.format_label(asset)
                     with SuppressValidationError():
                         ip_seed = IpSeed(value=ip_address, label=label)
                         self.add_seed(ip_seed)
                         self.possible_labels.discard(label)
+                    if domain := ip_address_dict.get("fqdn"):
+                        with SuppressValidationError():
+                            domain_seed = DomainSeed(value=domain, label=label)
+                            self.add_seed(domain_seed)
+                            self.possible_labels.discard(label)
+
+        except AzureError as error:
+            raise CensysAzureException(
+                message=f"Failed to get Azure Container Instances: {error.message}"
+            )
+
+    def get_sql_servers(self):
+        """Get Azure SQL servers.
+
+        Raises:
+            CensysAzureException: If Azure reports an error.
+        """
+        sql_client = SqlManagementClient(self.credentials, self.subscription_id)
+
+        try:
+            assets = sql_client.servers.list()
+
+            for asset in assets:
+                asset_dict = asset.as_dict()
+                if (
+                    domain := asset_dict.get("fully_qualified_domain_name")
+                ) and asset_dict.get("public_network_access") == "Enabled":
+                    with SuppressValidationError():
+                        label = self.format_label(asset)
+                        domain_seed = DomainSeed(value=domain, label=label)
+                        self.add_seed(domain_seed)
+                        self.possible_labels.discard(label)
+
+        except AzureError as error:
+            raise CensysAzureException(
+                message=f"Failed to get Azure SQL servers: {error.message}"
+            )
+
+    def get_dns_records(self):
+        """Get Azure DNS records.
+
+        Raises:
+            CensysAzureException: If Azure reports an error.
+        """
+        dns_client = DnsManagementClient(self.credentials, self.subscription_id)
+
+        try:
+            zones = dns_client.zones.list()
+
+            # Note: for loop is included in try/catch block because it's possible
+            # for HttpResponseError to be raised while iterating through zones.
+            for zone in zones:
+                zone_dict = zone.as_dict()
+                label = self.format_label(zone)
+                # TODO: Do we need to check if zone is public? (ie. do we care?)
+                if zone_dict.get("zone_type") != "Public":  # pragma: no cover
+                    continue
+                zone_resource_group = zone_dict.get("id").split("/")[4]
+                for asset in dns_client.record_sets.list_all_by_dns_zone(
+                    zone_resource_group, zone_dict.get("name")
+                ):
+                    asset_dict = asset.as_dict()
+                    if domain_name := asset_dict.get("fqdn"):
+                        with SuppressValidationError():
+                            domain_seed = DomainSeed(value=domain_name, label=label)
+                            self.add_seed(domain_seed)
+                            self.possible_labels.discard(label)
+                    if cname := asset_dict.get("cname_record", {}).get("cname"):
+                        with SuppressValidationError():
+                            domain_seed = DomainSeed(value=cname, label=label)
+                            self.add_seed(domain_seed)
+                            self.possible_labels.discard(label)
+                    for a_record in asset_dict.get("a_records", []):
+                        ip_address = a_record.get("ipv4_address")
+                        if not ip_address:
+                            continue
+
+                        with SuppressValidationError():
+                            ip_seed = IpSeed(value=ip_address, label=label)
+                            self.add_seed(ip_seed)
+                            self.possible_labels.discard(label)
+
+        except AzureError as error:
+            raise CensysAzureException(
+                message=f"Failed to get Azure DNS records: {error.message}"
+            )
 
     def _list_containers(
         self, bucket_client: BlobServiceClient, account: StorageAccount
@@ -254,55 +283,63 @@ class AzureCloudConnector(CloudConnector):
 
         Yields:
             ContainerProperties: Azure container properties.
+
+        Raises:
+            CensysAzureException: If Azure reports an error.
         """
         try:
             yield from bucket_client.list_containers()
-        except HttpResponseError as error:
-            self.logger.error(
-                f"Failed to get Azure containers for {account.name}: {error.message}"
+        except AzureError as error:
+            raise CensysAzureException(
+                message=f"Failed to get Azure containers for {account.name}: {error.message}"
             )
-            return
 
     def get_storage_containers(self):
-        """Get Azure containers."""
+        """Get Azure containers.
+
+        Raises:
+            CensysAzureException: If Azure reports an error.
+        """
         storage_client = StorageManagementClient(self.credentials, self.subscription_id)
         try:
             accounts = storage_client.storage_accounts.list()
-        except HttpResponseError as error:
-            self.logger.error(f"Failed to get Azure storage accounts: {error.message}")
-            return
 
-        for account in accounts:
-            bucket_client = BlobServiceClient(
-                f"https://{account.name}.blob.core.windows.net/", self.credentials
-            )
-            label = self.format_label(account)
-            account_dict = account.as_dict()
-            if (custom_domain := account_dict.get("custom_domain")) and (
-                domain := custom_domain.get("name")
-            ):
-                with SuppressValidationError():
-                    domain_seed = DomainSeed(value=domain, label=label)
-                    self.add_seed(domain_seed)
-                    self.possible_labels.discard(label)
-            uid = f"{self.subscription_id}/{self.credentials._tenant_id}/{account.name}"
-
-            for container in self._list_containers(bucket_client, account):
-                try:
-                    container_client = bucket_client.get_container_client(container)
-                    container_url = container_client.url
+            for account in accounts:
+                bucket_client = BlobServiceClient(
+                    f"https://{account.name}.blob.core.windows.net/", self.credentials
+                )
+                label = self.format_label(account)
+                account_dict = account.as_dict()
+                if (custom_domain := account_dict.get("custom_domain")) and (
+                    domain := custom_domain.get("name")
+                ):
                     with SuppressValidationError():
-                        container_asset = AzureContainerAsset(
-                            value=container_url,
-                            uid=uid,
-                            scan_data={
-                                "accountNumber": self.subscription_id,
-                                "publicAccess": container.public_access,
-                                "location": account.location,
-                            },
+                        domain_seed = DomainSeed(value=domain, label=label)
+                        self.add_seed(domain_seed)
+                        self.possible_labels.discard(label)
+                uid = f"{self.subscription_id}/{self.credentials._tenant_id}/{account.name}"
+
+                for container in self._list_containers(bucket_client, account):
+                    try:
+                        container_client = bucket_client.get_container_client(container)
+                        container_url = container_client.url
+                        with SuppressValidationError():
+                            container_asset = AzureContainerAsset(
+                                value=container_url,
+                                uid=uid,
+                                scan_data={
+                                    "accountNumber": self.subscription_id,
+                                    "publicAccess": container.public_access,
+                                    "location": account.location,
+                                },
+                            )
+                            self.add_cloud_asset(container_asset)
+                    except ServiceRequestError as error:  # pragma: no cover
+                        raise CensysAzureException(
+                            message=f"Failed to get Azure container {container} for {account.name}: {error.message}"
                         )
-                        self.add_cloud_asset(container_asset)
-                except ServiceRequestError as error:  # pragma: no cover
-                    self.logger.error(
-                        f"Failed to get Azure container {container} for {account.name}: {error.message}"
-                    )
+
+        except AzureError as error:
+            raise CensysAzureException(
+                message=f"Failed to get Azure storage accounts: {error.message}"
+            )

--- a/src/censys/cloud_connectors/common/cli/args.py
+++ b/src/censys/cloud_connectors/common/cli/args.py
@@ -30,7 +30,10 @@ def get_parser() -> argparse.ArgumentParser:
 
     for command in commands.__dict__.values():
         try:
-            # FIXME: This is weird and doesn't just include the commands
+            # Note: The way this is currently implemented, the function
+            # `include_cli` needs to be passed into the parent parser to
+            # include the commands in the parsing. For the future, implementing
+            # dynamic parsing of commands would require refactoring here.
             include_func = command.include_cli
         except AttributeError:
             continue

--- a/src/censys/cloud_connectors/common/exceptions.py
+++ b/src/censys/cloud_connectors/common/exceptions.py
@@ -1,0 +1,86 @@
+"""Exceptions for the Cloud Connectors."""
+from typing import Optional
+
+
+class CensysCloudConnectorException(Exception):
+    """Base Exception for Censys Cloud Connectors."""
+
+
+class CensysCloudProviderException(CensysCloudConnectorException):
+    """Base Exception for Censys Cloud Connector Cloud Providers."""
+
+    def __init__(
+        self,
+        message: str,
+        status_code: Optional[int] = None,
+        body: Optional[str] = None,
+        const: Optional[str] = None,
+        details: Optional[str] = None,
+    ):
+        """Inits CensysCloudProviderException.
+
+        Args:
+            message (str): HTTP message.
+            status_code (int): Optional; HTTP status code.
+            body (str): Optional; HTTP body.
+            const (str): Optional; Constant for manual errors.
+            details (str): Optional; Additional details.
+        """
+        self.message = message
+        self.status_code = status_code
+        self.body = body
+        self.const = const
+        self.details = details
+        super().__init__(self.message)
+
+    def __repr__(self) -> str:
+        """Representation of CensysCloudProviderException.
+
+        Returns:
+            str: Printable representation.
+        """
+        return f"{self.message}"
+
+    __str__ = __repr__
+
+
+class CensysAzureException(CensysCloudProviderException):
+    """Azure Exception for Censys Cloud Connectors."""
+
+    def __repr__(self) -> str:
+        """Representation of CensysAzureException.
+
+        Returns:
+            str: Printable representation.
+        """
+        return f"{self.message}"
+
+    __str__ = __repr__
+
+
+class CensysGcpException(CensysCloudProviderException):
+    """Gcp Exception for Censys Cloud Connectors."""
+
+    def __repr__(self) -> str:
+        """Representation of CensysGcpException.
+
+        Returns:
+            str: Printable representation.
+        """
+        return f"{self.message}"
+
+    __str__ = __repr__
+
+
+class CensysAwsException(CensysCloudProviderException):
+    """Aws Exception for Censys Cloud Connectors."""
+
+    def __repr__(self) -> str:
+        """Representation of CensysAwsException.
+
+        Returns:
+            str: Printable representation.
+        """
+        return f"{self.message}"
+
+    __str__ = __repr__


### PR DESCRIPTION
## Changes
- Define generic Censys Cloud Connector exceptions for each cloud provider
- Catch Azure error `(BadRequest) The specified subscription <SUBSCRIPTION_ID> does not exist` gracefully and allow run to continue
- Add information about this error to FAQ section in docs

### Unrelated, minor changes
- Add missing `credentialsSecretName` to kubernetes docs configuration table
- Skip removal of stale seeds when `DRY_RUN` is set to true